### PR TITLE
Unpin setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=62.3", "wheel~=0.37.1"]
+requires = ["setuptools>=62.3"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
setuptools is now at version 68. I'm creating this patch to use in [nixpkgs](https://github.com/NixOS/nixpkgs), but I hope it can be accepted here as well. I have also removed `wheel` because a PEP 517 build front-end will ask setuptools for what dependencies it needs to build a wheel, and setuptools will pull it in as needed. Per [the documentation](https://setuptools.pypa.io/en/latest/userguide/quickstart.html):

> Historically this documentation has unnecessarily listed wheel in the requires list, and many projects still do that. This is not recommended. The backend automatically adds wheel dependency when it is required, and listing it explicitly causes it to be unnecessarily required for source distribution builds. You should only include wheel in requires if you need to explicitly access it during build time (e.g. if your project needs a setup.py script that imports wheel).