### PR TITLE
Dialog improvements

### DIFF
--- a/src/config/dialog-add-device-override.ts
+++ b/src/config/dialog-add-device-override.ts
@@ -74,11 +74,9 @@ class DialogAddDeviceOverride extends LitElement {
               </div>
             `
           : html`
-        <div class="buttons">
           <ha-button @click=${this._submit} slot="primaryAction">
             ${this.insteon!.localize("common.ok")}
           </ha-button>
-        </div>
       </ha-dialog>`}
       </ha-dialog>
     `;

--- a/src/config/dialog-config-modem.ts
+++ b/src/config/dialog-config-modem.ts
@@ -96,11 +96,9 @@ class DialogInsteonConfigModem extends LitElement {
               </div>
             `
           : html`
-        <div class="buttons">
           <ha-button @click=${this._submit} .disabled=${!this._hasChanged} slot="primaryAction">
             ${this.insteon!.localize("common.ok")}
           </ha-button>
-        </div>
       </ha-dialog>`}
       </ha-dialog>
     `;

--- a/src/config/dialog-delete-device.ts
+++ b/src/config/dialog-delete-device.ts
@@ -69,14 +69,12 @@ class DialogDeleteDevice extends LitElement {
             @value-changed=${this._valueChanged}
           ></ha-form>
         </div>
-        <div class="buttons">
-          <ha-button @click=${this._dismiss} slot="secondaryAction">
-            ${this.hass.localize("ui.common.cancel")}
-          </ha-button>
-          <ha-button @click=${this._submit} slot="primaryAction">
-            ${this.hass.localize("ui.common.ok")}
-          </ha-button>
-        </div>
+        <ha-button @click=${this._dismiss} slot="primaryAction" appearance="plain">
+          ${this.hass.localize("ui.common.cancel")}
+        </ha-button>
+        <ha-button @click=${this._submit} slot="primaryAction">
+          ${this.hass.localize("ui.common.ok")}
+        </ha-button>
       </ha-dialog>
     `;
   }

--- a/src/device/aldb/dialog-insteon-aldb-record.ts
+++ b/src/device/aldb/dialog-insteon-aldb-record.ts
@@ -72,14 +72,12 @@ class DialogInsteonALDBRecord extends LitElement {
             @value-changed=${this._valueChanged}
           ></ha-form>
         </div>
-        <div class="buttons">
-          <ha-button @click=${this._dismiss} slot="secondaryAction">
-            ${this.hass.localize("ui.common.cancel")}
-          </ha-button>
-          <ha-button @click=${this._submit} slot="primaryAction">
-            ${this.hass.localize("ui.common.ok")}
-          </ha-button>
-        </div>
+        <ha-button @click=${this._dismiss} slot="primaryAction" appearance="plain">
+          ${this.hass.localize("ui.common.cancel")}
+        </ha-button>
+        <ha-button @click=${this._submit} slot="primaryAction">
+          ${this.hass.localize("ui.common.ok")}
+        </ha-button>
       </ha-dialog>
     `;
   }

--- a/src/device/dialog-device-add-x10.ts
+++ b/src/device/dialog-device-add-x10.ts
@@ -62,14 +62,12 @@ class DialogInsteonDeviceAddX10 extends LitElement {
             .computeLabel=${this._computeLabel(this.insteon?.localize)}
           ></ha-form>
         </div>
-        <div class="buttons">
-          <ha-button @click=${this._dismiss} slot="secondaryAction">
-            ${this.insteon!.localize("common.cancel")}
-          </ha-button>
-          <ha-button @click=${this._submit} slot="primaryAction">
-            ${this.insteon!.localize("common.ok")}
-          </ha-button>
-        </div>
+        <ha-button @click=${this._dismiss} slot="primaryAction" appearance="plain">
+          ${this.insteon!.localize("common.cancel")}
+        </ha-button>
+        <ha-button @click=${this._submit} slot="primaryAction">
+          ${this.insteon!.localize("common.ok")}
+        </ha-button>
       </ha-dialog>
     `;
   }

--- a/src/device/dialog-insteon-add-device.ts
+++ b/src/device/dialog-insteon-add-device.ts
@@ -1,5 +1,5 @@
 import type { CSSResultGroup, TemplateResult } from "lit";
-import { css, html, LitElement } from "lit";
+import { html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import "@ha/components/ha-code-editor";
 import { createCloseHeading } from "@ha/components/ha-dialog";
@@ -70,14 +70,12 @@ class DialogInsteonAddDevice extends LitElement {
             .computeLabel=${this._computeLabel(this.insteon?.localize)}
           ></ha-form>
         </div>
-        <div class="buttons">
-          <ha-button @click=${this._dismiss} slot="secondaryAction">
-            ${this.insteon!.localize("common.cancel")}
-          </ha-button>
-          <ha-button @click=${this._submit} slot="primaryAction">
-            ${this.insteon!.localize("common.ok")}
-          </ha-button>
-        </div>
+        <ha-button @click=${this._dismiss} slot="primaryAction" appearance="plain">
+          ${this.insteon!.localize("common.cancel")}
+        </ha-button>
+        <ha-button @click=${this._submit} slot="primaryAction">
+          ${this.insteon!.localize("common.ok")}
+        </ha-button>
       </ha-dialog>
     `;
   }
@@ -122,20 +120,7 @@ class DialogInsteonAddDevice extends LitElement {
   }
 
   static get styles(): CSSResultGroup[] {
-    return [
-      haStyleDialog,
-      css`
-        table {
-          width: 100%;
-        }
-        ha-combo-box {
-          width: 20px;
-        }
-        .title {
-          width: 200px;
-        }
-      `,
-    ];
+    return [haStyleDialog];
   }
 }
 

--- a/src/device/dialog-insteon-adding-device.ts
+++ b/src/device/dialog-insteon-adding-device.ts
@@ -63,11 +63,9 @@ class DialogInsteonAddingDevice extends LitElement {
         <div class="instructions">${this._showInstructions()}</div>
         <br />
         <div class="devices">${this._devicesAddedText}</div>
-        <div class="buttons">
-          <ha-button @click=${this._checkCancel} slot="primaryAction">
-            ${this._buttonText(this._subscribed)}
-          </ha-button>
-        </div>
+        <ha-button @click=${this._checkCancel} slot="primaryAction">
+          ${this._buttonText(this._subscribed)}
+        </ha-button>
       </ha-dialog>
     `;
   }

--- a/src/device/properties/dialog-insteon-property.ts
+++ b/src/device/properties/dialog-insteon-property.ts
@@ -75,14 +75,12 @@ class DialogInsteonProperty extends LitElement {
             .error=${this._errors}
           ></ha-form>
         </div>
-        <div class="buttons">
-          <ha-button appearance="plain" @click=${this._dismiss} slot="secondaryAction">
-            ${this.hass.localize("ui.common.cancel")}
-          </ha-button>
-          <ha-button appearance="plain" @click=${this._submit} slot="primaryAction">
-            ${this.hass.localize("ui.common.ok")}
-          </ha-button>
-        </div>
+        <ha-button @click=${this._dismiss} slot="primaryAction" appearance="plain">
+          ${this.hass.localize("ui.common.cancel")}
+        </ha-button>
+        <ha-button @click=${this._submit} slot="primaryAction">
+          ${this.hass.localize("ui.common.ok")}
+        </ha-button>
       </ha-dialog>
     `;
   }

--- a/src/scene/dialog-insteon-scene-set-on-level.ts
+++ b/src/scene/dialog-insteon-scene-set-on-level.ts
@@ -50,7 +50,7 @@ class DialogInsteonSetOnLevel extends LitElement {
     this._callback = params.callback;
     this._title = params.title;
     this._opened = true;
-    this._value = params.value;
+    this._value = this._convertToSliderValue(params.value);
     this._ramp_rate = params.ramp_rate;
     this._address = params.address;
     this._group = params.group;
@@ -71,6 +71,8 @@ class DialogInsteonSetOnLevel extends LitElement {
     if (!this._opened) {
       return html``;
     }
+
+    const formatter = new Intl.NumberFormat("en-US", { style: "percent" });
     return html`
       <ha-dialog
         open
@@ -83,11 +85,14 @@ class DialogInsteonSetOnLevel extends LitElement {
             ignore-bar-touch
             .value=${this._value}
             .min=${0}
-            .max=${255}
+            .max=${1}
+            .step=${0.01}
             .disabled=${false}
+            .label=${this.insteon?.localize("scenes.scene.devices.on_level")}
+            .valueFormatter=${formatter.format}
             @change=${this._valueChanged}
           ></ha-slider>
-
+          <br />
           <ha-selector-select
             .hass=${this.hass}
             .value=${"" + this._ramp_rate}
@@ -97,14 +102,12 @@ class DialogInsteonSetOnLevel extends LitElement {
             @value-changed=${this._rampRateChanged}
           ></ha-selector-select>
         </div>
-        <div class="buttons">
-          <ha-button @click=${this._dismiss} slot="secondaryAction">
-            ${this.insteon!.localize("common.cancel")}
-          </ha-button>
-          <ha-button @click=${this._submit} slot="primaryAction">
-            ${this.insteon!.localize("common.ok")}
-          </ha-button>
-        </div>
+        <ha-button @click=${this._dismiss} slot="primaryAction" appearance="plain">
+          ${this.insteon!.localize("common.cancel")}
+        </ha-button>
+        <ha-button @click=${this._submit} slot="primaryAction">
+          ${this.insteon!.localize("common.ok")}
+        </ha-button>
       </ha-dialog>
     `;
   }
@@ -117,7 +120,12 @@ class DialogInsteonSetOnLevel extends LitElement {
     // eslint-disable-next-line no-console
     console.info("Should be calling callback");
     this._close();
-    await this._callback!(this._address, this._group, this._value, this._ramp_rate);
+    await this._callback!(
+      this._address,
+      this._group,
+      this._convertFromSliderValue(this._value),
+      this._ramp_rate,
+    );
   }
 
   private _close(): void {
@@ -130,6 +138,15 @@ class DialogInsteonSetOnLevel extends LitElement {
 
   private _rampRateChanged(ev: CustomEvent) {
     this._ramp_rate = +ev.detail?.value;
+  }
+
+  private _convertToSliderValue(value: number): number {
+    const converted = value / 255;
+    return Number.parseFloat(converted.toFixed(2));
+  }
+
+  private _convertFromSliderValue(value: number): number {
+    return Math.round(value * 255);
   }
 
   static get styles(): CSSResultGroup[] {


### PR DESCRIPTION
Fixes the rendering of buttons on multiple dialogs. Buttons are now rendered in the right-hand side of the dialog footer and match the style of other buttons in Home Assistant.

## Screenshots 
### Add device dialog
Before:
<img width="403" height="422" alt="image" src="https://github.com/user-attachments/assets/01a4960f-c4cd-4416-a616-d0bcb926117b" />
After:
<img width="399" height="388" alt="image" src="https://github.com/user-attachments/assets/b9577eda-2af9-4c4b-a4e5-0b797dc4eeaa" />

### Adding Insteon Device
Before:
<img width="581" height="237" alt="image" src="https://github.com/user-attachments/assets/db10ba76-dfd8-40b9-91b0-c9ae5f9dc05f" />
After:
<img width="584" height="226" alt="image" src="https://github.com/user-attachments/assets/2c29b873-9ba8-4973-97be-06d139dafcb7" />

### Adding X10 Device
Before:
<img width="396" height="567" alt="image" src="https://github.com/user-attachments/assets/813dd2a4-10dc-4d4f-a32a-dcdac8b4f6af" />
After:
<img width="402" height="548" alt="image" src="https://github.com/user-attachments/assets/ccc69f6e-86c3-40b9-b474-994063b17697" />

## Insteon Scene On-Level Dialog

Additionally, the dialog shown when adjusting a dimmable device's on-level in a scene now uses a percentage-based setting rather than 0-255 and the slider has spacing around it

Before:
<img width="398" height="266" alt="image" src="https://github.com/user-attachments/assets/24d9fd7e-bfe2-4623-8655-f82157adb470" />

After:
<img width="398" height="303" alt="image" src="https://github.com/user-attachments/assets/5863e452-b062-4ac2-8367-d2c52fd5ee60" />


