### PR TITLE
Migrate PyPI publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/ReleaseActions.yml
+++ b/.github/workflows/ReleaseActions.yml
@@ -11,6 +11,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Deploy to PyPi
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -34,16 +36,14 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install build twine
+          python -m pip install build
           ./script/bootstrap
 
-      - name: Build
+      - name: Build frontend
         run: yarn build
 
+      - name: Build Python distribution
+        run: python -m build
+
       - name: Publish to PyPi
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          python -m build
-          twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
Migrate the release workflow from a long-lived `PYPI_TOKEN` API token to **PyPI Trusted Publishing** via `pypa/gh-action-pypi-publish`. The workflow now requests a short-lived OIDC token from GitHub at job runtime; PyPI exchanges it for a one-shot upload credential.

The 0.6.2 release run failed with a `403 Forbidden` from PyPI on `twine upload`, which is almost certainly a stale/revoked API token. Trusted Publishing fixes this class of outage permanently — no token to rotate, no secret to leak.

## Changes
- Add `permissions: id-token: write` to the `deploy` job (required for OIDC).
- Replace `twine upload` + `TWINE_USERNAME`/`TWINE_PASSWORD` env vars with `pypa/gh-action-pypi-publish@release/v1`.
- Drop `twine` from the pip install (the action handles upload).
- Split `python -m build` into its own step for clearer logs.

## ⚠️ Required out-of-band setup before merging
Before this workflow can publish, a Trusted Publisher must be configured on PyPI:

1. Go to https://pypi.org/manage/project/insteon-frontend-home-assistant/settings/publishing/
2. Add a **GitHub** publisher with:
   - Owner: `pyinsteon`
   - Repository: `insteon-panel`
   - Workflow filename: `ReleaseActions.yml`
   - Environment name: *(leave blank, unless you want to gate releases behind a GitHub deployment environment — recommended for production but optional)*
3. Save.

Once configured, the existing `PYPI_TOKEN` repo secret can be deleted.

## Test plan
- [ ] PyPI Trusted Publisher configured per above
- [ ] Cut a fresh release (e.g. `0.6.3`) once the failed `0.6.2` upload is reconciled — confirm the workflow succeeds end-to-end and the new version appears on https://pypi.org/project/insteon-frontend-home-assistant/
- [ ] Delete the now-unused `PYPI_TOKEN` repo secret

## Notes on the failed 0.6.2 release
PyPI rejected the upload with 403, so version `0.6.2` is still available for upload. Options:
- Re-cut the `0.6.2` release after this PR is merged + Trusted Publisher is configured.
- Or bump to `0.6.3` for cleanliness; the failed run pollutes the history but causes no harm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)