### PR TITLE
Only show broken link actions that fit the row

### DIFF
--- a/src/config/broken-links-panel.ts
+++ b/src/config/broken-links-panel.ts
@@ -1,4 +1,4 @@
-import { mdiInformationOutline } from "@mdi/js";
+import { mdiDatabaseRefreshOutline, mdiDeleteOutline, mdiLinkPlus } from "@mdi/js";
 import type { TemplateResult } from "lit";
 import { LitElement, html } from "lit";
 import { customElement, property, state } from "lit/decorators";
@@ -139,28 +139,8 @@ export class BrokenLinksPanel extends LitElement {
       actions: {
         title: "",
         type: "overflow-menu",
-        template: (record) => html`
-          <ha-icon-overflow-menu
-            .hass=${this.hass}
-            narrow
-            .items=${[
-              {
-                path: mdiInformationOutline,
-                label: this.insteon.localize("utils.broken_links.actions.target_db_not_loaded"),
-                action: () => this._handleReloadAldb(record),
-              },
-              {
-                path: mdiInformationOutline,
-                label: this.insteon.localize("utils.broken_links.actions.missing_responder"),
-                action: () => this._handleDeleteRecord(record),
-              },
-              {
-                path: mdiInformationOutline,
-                label: this.insteon.localize("utils.broken_links.actions.missing_controller"),
-                action: () => this._handleCreateRecord(record),
-              },
-            ]}
-          >
+        template: (record: BrokenLinkRowData) => html`
+          <ha-icon-overflow-menu .hass=${this.hass} narrow .items=${this._rowActions(record)}>
           </ha-icon-overflow-menu>
         `,
       },
@@ -192,6 +172,43 @@ export class BrokenLinksPanel extends LitElement {
     });
     return broken_link_list;
   });
+
+  private _rowActions(record: BrokenLinkRowData) {
+    const status = record.status as unknown as string;
+    if (status === "target_db_not_loaded") {
+      return [
+        {
+          path: mdiDatabaseRefreshOutline,
+          label: this.insteon.localize("utils.broken_links.actions.target_db_not_loaded"),
+          action: () => this._handleReloadAldb(record),
+        },
+      ];
+    }
+    if (status === "missing_controller" || status === "missing_responder") {
+      return [
+        {
+          path: mdiLinkPlus,
+          label: this.insteon.localize("utils.broken_links.actions.create_missing"),
+          action: () => this._handleCreateRecord(record),
+        },
+        {
+          path: mdiDeleteOutline,
+          label: this.insteon.localize("utils.broken_links.actions.delete_record"),
+          action: () => this._handleDeleteRecord(record),
+        },
+      ];
+    }
+    if (status === "missing_target") {
+      return [
+        {
+          path: mdiDeleteOutline,
+          label: this.insteon.localize("utils.broken_links.actions.delete_record"),
+          action: () => this._handleDeleteRecord(record),
+        },
+      ];
+    }
+    return [];
+  }
 
   private async _handleReloadAldb(record: BrokenLinkRowData) {
     showConfirmationDialog(this, {
@@ -228,17 +245,21 @@ export class BrokenLinksPanel extends LitElement {
   }
 
   private async _handleCreateRecord(record: BrokenLinkRowData) {
+    // The new record is the complement of the surviving half. A new
+    // responder gets on-level and ramp defaults; a new controller gets
+    // the button number in data3.
+    const creating_controller = !record.is_controller;
     const aldb_rec: ALDBRecord = {
       mem_addr: 0,
       in_use: true,
-      is_controller: !record.is_controller,
+      is_controller: creating_controller,
       highwater: false,
       group: record.group,
       target: record.address,
       target_name: "",
-      data1: 255,
-      data2: 0,
-      data3: 1,
+      data1: creating_controller ? 3 : 255,
+      data2: creating_controller ? 0 : 28,
+      data3: creating_controller ? record.group : 1,
       dirty: true,
     };
     this._selected_device = record.target;

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -105,12 +105,16 @@
       "actions": {
         "target_db_not_loaded": "Load All-Link Database",
         "missing_responder": "Delete existing record",
-        "missing_controller": "Create missing record"
+        "missing_controller": "Create missing record",
+        "create_missing": "Create missing record",
+        "delete_record": "Delete this record",
+        "missing_target": "Delete this record"
       },
       "status": {
         "target_db_not_loaded": "All-Link Database not loaded",
         "missing_responder": "Missing responder record",
-        "missing_controller": "Missing controller record"
+        "missing_controller": "Missing controller record",
+        "missing_target": "Target device does not exist"
       },
       "load_aldb": "The All-Link Database for device ",
       "load_aldb_1": " will load in the background. If this is a battery operated device, you will need to trigger the device to wake up before the ALDB will load.",


### PR DESCRIPTION
## What this changes

The broken links table currently offers the same three actions on every row regardless of its status: Load All-Link Database, Create missing record, and Delete this record. Two of those are usually wrong for any given row, and one of them is destructive. This PR replaces the fixed menu with a per-row action menu derived from the row's status:

| Status | Actions shown |
|---|---|
| All-Link Database not loaded | Load All-Link Database (only) |
| Missing responder record | Create missing record, Delete this record |
| Missing controller record | Create missing record, Delete this record |
| Target device does not exist | Delete this record (only) |

The `target_db_not_loaded` case matters most: those rows cannot be verified yet, so the destructive actions are not offered at all. The Recommendation column keeps suggesting the likely fix for the two-action rows.

Create missing record seeds the complementary half from the surviving record: on level 255 and ramp 28 for a new responder, and the button number carried into data3 for a new controller.

## How it was validated

Run against a live 35-device network via the dev_path override. The live broken links list contained all four statuses, including `target_db_not_loaded` rows pointing at a failed device, missing responder rows from a half-created three-way group, and records referencing a modem that no longer exists. Menus rendered the expected action set for each status.
